### PR TITLE
Allow pickle serialization of ByteRL instances

### DIFF
--- a/gym_locm/agents/byterl/model.py
+++ b/gym_locm/agents/byterl/model.py
@@ -30,6 +30,10 @@ def softmax(x):
     return np.exp(x) / np.sum(np.exp(x))
 
 
+def identity(x):
+    return x
+
+
 def _activation(activation_name):
     if activation_name == "relu":
         return relu
@@ -38,7 +42,7 @@ def _activation(activation_name):
     elif activation_name == "gelu":
         return gelu
     else:
-        return lambda x: x
+        return identity
 
 
 class fully_connected_layers:


### PR DESCRIPTION
Replaces the local anonymous lambda function inside _activation with a module-level identity function to allow pickling ByteRL model classes.